### PR TITLE
fix: show emoji icon while logo loads, fall back on error

### DIFF
--- a/app.js
+++ b/app.js
@@ -208,9 +208,10 @@ function buildCardHTML(svc) {
 			<span class="s-value">${s.value}</span>
 		</div>`).join('');
 
+	const fallbackIcon = svc.icon ?? '⚙️';
 	const iconHTML = svc.logo
-		? `<img src="logos/${svc.logo}" alt="${svc.name}" class="service-logo-img">`
-		: (svc.icon ?? '⚙️');
+		? `<span class="service-icon-emoji">${fallbackIcon}</span><img src="logos/${svc.logo}" alt="${svc.name}" class="service-logo-img" style="display:none" onload="this.style.display='';this.previousElementSibling.style.display='none'" onerror="this.remove()">`
+		: fallbackIcon;
 
 	return `
 		<a href="${svc.url}" target="_blank" rel="noopener noreferrer" class="service-card" id="card-${id}" style="--card-accent:${color}" data-cat="${(svc.category ?? '').toLowerCase()}" data-name="${svc.name.toLowerCase()}" data-desc="${(svc.description ?? '').toLowerCase()}">


### PR DESCRIPTION
## Summary
- Service cards with a `logo` set now instantly show the emoji `icon` while the image loads
- Once the logo loads successfully, it swaps in and the emoji is hidden
- If the logo fails to load (e.g. file missing on a fresh install), the emoji remains visible — no broken image icon

## Test plan
- [ ] Fresh install with example services.yaml (no logos/ dir) — emoji icons should display cleanly
- [ ] Install with logos present — emoji should briefly show, then swap to logo on load
- [ ] Intentionally broken logo path — emoji should remain, no broken image icon shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)