### PR TITLE
fix: minor CSS change to fix alignments

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -950,9 +950,7 @@ body {
   margin-top: auto;
   width: 100%; /* prevents wrapper expanding when chips are width: max-content */
 }
-body.hide-descriptions-mode .stats-scroll-wrapper {
-  margin-top: auto;
-}
+
 .service-stats {
   display: flex;
   flex-wrap: nowrap;


### PR DESCRIPTION
Removes some of the empty space around descriptions when placed next to a service with live stats.