### PR TITLE
feat: theme browser scrollbar to match dashboard design

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -97,6 +97,19 @@ body {
   overflow-x: hidden;
 }
 
+/* ── Scrollbar ───────────────────────────────────────────────────────────────── */
+/* Firefox */
+html {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.12) transparent;
+}
+/* Chromium (Chrome, Edge, Brave) */
+::-webkit-scrollbar              { width: 6px; height: 6px; }
+::-webkit-scrollbar-track        { background: transparent; }
+::-webkit-scrollbar-thumb        { background: rgba(255, 255, 255, 0.12); border-radius: 99px; }
+::-webkit-scrollbar-thumb:hover  { background: rgba(255, 255, 255, 0.22); }
+::-webkit-scrollbar-corner       { background: transparent; }
+
 /* ── Background Layer ───────────────────────────────────────────────────────── */
 .bg-layer {
   position: fixed;


### PR DESCRIPTION
## Summary

- Styled the browser scrollbar to suit the dark dashboard aesthetic — 6px wide (down from the browser default ~15px), transparent track, subtle white-alpha thumb that brightens slightly on hover
- Covers both Firefox (`scrollbar-width: thin` + `scrollbar-color`) and Chromium browsers (`::webkit-scrollbar` rules)
- Applied globally so it covers the main page, changelog modal, and any future scrollable areas — existing per-element overrides (`#cat-nav`, hidden `.service-stats`, etc.) continue to take precedence unchanged

## Test plan

- [ ] Confirm scrollbar appears on the main content area when services overflow
- [ ] Confirm scrollbar appears in the changelog modal body
- [ ] Check in both a Chromium browser (Chrome/Edge/Brave) and Firefox
- [ ] Verify the thumb brightens on hover
- [ ] Confirm the category nav and service stats scrollbars are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)