### PR TITLE
Beta → Main: card zoom control (floating widget)

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,7 +4,7 @@ import { state }                 from './js/state.js';
 import { svcId, debounce }       from './js/utils.js';
 import { renderServices }        from './js/render.js';
 import { loadServices, refreshAll, clearServiceTimers, startServiceTimers } from './js/services.js';
-import { buildSidebarSections, initFilters, initViewToggle, initSortToggle, initSidebarToggle, startClock, stopClock, startCountdown, stopCountdown } from './js/ui.js';
+import { buildSidebarSections, initFilters, initViewToggle, initSortToggle, initZoomControl, initSidebarToggle, startClock, stopClock, startCountdown, stopCountdown } from './js/ui.js';
 import { startPingPolling, stopPingPolling } from './js/ping.js';
 import { checkForUpdate, initChangelog } from './js/updates.js';
 
@@ -14,6 +14,7 @@ async function init() {
 	initFilters();
 	initViewToggle();
 	initSortToggle();
+	initZoomControl();
 	initChangelog();
 	checkForUpdate(); // fire-and-forget — updates UI when response arrives
 

--- a/index.html
+++ b/index.html
@@ -157,6 +157,20 @@
               <path class="arrow-up"   d="M7.5 5.5l2-2.5 2 2.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
           </button>
+          <div class="view-toggle-sep" aria-hidden="true"></div>
+          <button class="view-btn" id="zoom-out-btn" title="Zoom out" aria-label="Zoom out">
+            <svg viewBox="0 0 14 14" fill="none" aria-hidden="true">
+              <path d="M2 7h10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+            </svg>
+          </button>
+          <button class="view-btn zoom-level-btn" id="zoom-level-btn" title="Reset zoom" aria-label="Reset zoom">
+            <span id="zoom-level">100%</span>
+          </button>
+          <button class="view-btn" id="zoom-in-btn" title="Zoom in" aria-label="Zoom in">
+            <svg viewBox="0 0 14 14" fill="none" aria-hidden="true">
+              <path d="M7 2v10M2 7h10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+            </svg>
+          </button>
         </div>
         <div class="clock" id="clock" aria-live="off"></div>
       </header>

--- a/index.html
+++ b/index.html
@@ -157,20 +157,6 @@
               <path class="arrow-up"   d="M7.5 5.5l2-2.5 2 2.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
           </button>
-          <div class="view-toggle-sep" aria-hidden="true"></div>
-          <button class="view-btn" id="zoom-out-btn" title="Zoom out" aria-label="Zoom out">
-            <svg viewBox="0 0 14 14" fill="none" aria-hidden="true">
-              <path d="M2 7h10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-            </svg>
-          </button>
-          <button class="view-btn zoom-level-btn" id="zoom-level-btn" title="Reset zoom" aria-label="Reset zoom">
-            <span id="zoom-level">100%</span>
-          </button>
-          <button class="view-btn" id="zoom-in-btn" title="Zoom in" aria-label="Zoom in">
-            <svg viewBox="0 0 14 14" fill="none" aria-hidden="true">
-              <path d="M7 2v10M2 7h10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-            </svg>
-          </button>
         </div>
         <div class="clock" id="clock" aria-live="off"></div>
       </header>
@@ -216,6 +202,22 @@
   <!-- Toast container -->
   <div id="sidebar-overlay"></div>
   <div id="toast-container" role="alert" aria-live="assertive" aria-atomic="true"></div>
+
+  <div id="zoom-widget" aria-label="Zoom controls">
+    <button class="zoom-widget-btn" id="zoom-out-btn" title="Zoom out" aria-label="Zoom out">
+      <svg viewBox="0 0 14 14" fill="none" aria-hidden="true">
+        <path d="M2 7h10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+      </svg>
+    </button>
+    <button class="zoom-widget-btn zoom-widget-level" id="zoom-level-btn" title="Reset zoom" aria-label="Reset zoom">
+      <span id="zoom-level">100%</span>
+    </button>
+    <button class="zoom-widget-btn" id="zoom-in-btn" title="Zoom in" aria-label="Zoom in">
+      <svg viewBox="0 0 14 14" fill="none" aria-hidden="true">
+        <path d="M7 2v10M2 7h10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+      </svg>
+    </button>
+  </div>
 
   <script type="module" src="app.js?v={{.AssetVer}}"></script>
 </body>

--- a/js/state.js
+++ b/js/state.js
@@ -12,6 +12,7 @@ export const state = {
 	statusFilter:    null,
 	dashView:        localStorage.getItem('dashView') ?? 'grouped',
 	sortAlpha:       localStorage.getItem('sortAlpha') || null,  // null | 'asc' | 'desc'
+	cardZoom:        parseFloat(localStorage.getItem('cardZoom')) || 1,
 	statusMap:       {},     // svcId → 'loading' | 'online' | 'offline'
 	statsMap:        {},     // svcId → stat chip array
 	svcTimers:       {},     // svcId → setInterval handle

--- a/js/ui.js
+++ b/js/ui.js
@@ -243,6 +243,37 @@ export function initSortToggle() {
 	});
 }
 
+// ── Card zoom control ─────────────────────────────────────────────────────────
+
+export function initZoomControl() {
+	const STEP = 0.1, MIN = 0.5, MAX = 1.5;
+
+	function applyZoom() {
+		const grid = document.getElementById('services-grid');
+		if (grid) grid.style.zoom = state.cardZoom;
+		const levelEl = document.getElementById('zoom-level');
+		if (levelEl) levelEl.textContent = `${Math.round(state.cardZoom * 100)}%`;
+		document.getElementById('zoom-out-btn')?.toggleAttribute('disabled', state.cardZoom <= MIN);
+		document.getElementById('zoom-in-btn')?.toggleAttribute('disabled',  state.cardZoom >= MAX);
+		localStorage.setItem('cardZoom', state.cardZoom);
+	}
+
+	document.getElementById('zoom-out-btn')?.addEventListener('click', () => {
+		state.cardZoom = Math.max(MIN, Math.round((state.cardZoom - STEP) * 10) / 10);
+		applyZoom();
+	});
+	document.getElementById('zoom-in-btn')?.addEventListener('click', () => {
+		state.cardZoom = Math.min(MAX, Math.round((state.cardZoom + STEP) * 10) / 10);
+		applyZoom();
+	});
+	document.getElementById('zoom-level-btn')?.addEventListener('click', () => {
+		state.cardZoom = 1;
+		applyZoom();
+	});
+
+	applyZoom();
+}
+
 // ── Sidebar toggle (mobile) ───────────────────────────────────────────────────
 
 export function initSidebarToggle() {

--- a/styles.css
+++ b/styles.css
@@ -759,6 +759,9 @@ html {
 .view-btn svg { width: 13px; height: 13px; pointer-events: none; display: block; }
 .view-btn:hover { color: var(--text-2); }
 .view-btn.active { background: var(--surface-hi); color: var(--text-1); }
+.view-btn:disabled { opacity: 0.3; pointer-events: none; }
+.zoom-level-btn { width: auto; padding: 0 0.4rem; font-family: var(--mono); font-size: 0.65rem; color: var(--text-3); }
+.zoom-level-btn:hover { color: var(--text-2); }
 .view-toggle-sep { width: 1px; height: 16px; background: var(--border); margin: 0 0.1rem; flex-shrink: 0; }
 #sort-alpha-btn .arrow-up            { display: none; }
 #sort-alpha-btn.sort-desc .arrow-down { display: none; }

--- a/styles.css
+++ b/styles.css
@@ -760,8 +760,47 @@ html {
 .view-btn:hover { color: var(--text-2); }
 .view-btn.active { background: var(--surface-hi); color: var(--text-1); }
 .view-btn:disabled { opacity: 0.3; pointer-events: none; }
-.zoom-level-btn { width: auto; padding: 0 0.4rem; font-family: var(--mono); font-size: 0.65rem; color: var(--text-3); }
-.zoom-level-btn:hover { color: var(--text-2); }
+
+/* ── Zoom widget (floating, bottom-right) ────────────────────────────────────── */
+#zoom-widget {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  display: flex;
+  align-items: center;
+  background: var(--bg-topbar);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid var(--border-hi);
+  border-radius: var(--radius-sm);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
+  overflow: hidden;
+  z-index: 50;
+  opacity: 0.5;
+  transition: opacity 0.2s;
+}
+#zoom-widget:hover { opacity: 1; }
+.zoom-widget-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  color: var(--text-3);
+  transition: background 0.15s, color 0.15s;
+  flex-shrink: 0;
+}
+.zoom-widget-btn:hover { background: var(--surface-hi); color: var(--text-1); }
+.zoom-widget-btn:disabled { opacity: 0.3; pointer-events: none; }
+.zoom-widget-btn svg { width: 12px; height: 12px; pointer-events: none; display: block; }
+.zoom-widget-level {
+  width: auto;
+  padding: 0 0.35rem;
+  font-family: var(--mono);
+  font-size: 0.64rem;
+  border-left: 1px solid var(--border);
+  border-right: 1px solid var(--border);
+}
 .view-toggle-sep { width: 1px; height: 16px; background: var(--border); margin: 0 0.1rem; flex-shrink: 0; }
 #sort-alpha-btn .arrow-up            { display: none; }
 #sort-alpha-btn.sort-desc .arrow-down { display: none; }


### PR DESCRIPTION
## Summary

- **Card zoom control:** Adds `−` / `100%` / `+` buttons as a floating pill widget fixed to the bottom-right corner of the page
- Zoom is applied via CSS `zoom` on `#services-grid`, scaling cards and all their contents proportionally
- Range: 50%–150% in 10% steps; persists to localStorage; `+`/`−` buttons disable at min/max limits
- Clicking the `100%` label resets to default zoom
- Widget fades to 50% opacity when not hovered so it stays out of the way

## Test plan

- [x] Zoom in/out scales cards and all content proportionally in both flat and grouped views
- [x] Zoom level persists after page reload
- [x] `+` disables at 150%, `−` disables at 50%
- [x] Clicking `100%` resets zoom
- [x] Widget is visible in bottom-right corner and doesn't overlap content awkwardly
- [x] Topbar alignment is unaffected on small displays

🤖 Generated with [Claude Code](https://claude.com/claude-code)