### PR TITLE
feat: add icons_only: mobile option

### DIFF
--- a/example.services.yaml
+++ b/example.services.yaml
@@ -55,6 +55,7 @@
 #
 #  icons_only field (settings only):
 #    Set to true to hide service names and show only icons for a compact layout.
+#    Set to "mobile" to apply icons-only mode on mobile screens only (≤840px).
 #
 #  hide_descriptions field (settings only):
 #    Set to true to hide description text on all cards.
@@ -66,7 +67,8 @@ settings:
   subtitle: "Home Server"
   refresh_interval: 30          # seconds between auto-refresh
   # emoji_stats: true           # show emojis instead of text labels on stat chips
-  # icons_only: true            # hide service names, show icons only
+  # icons_only: true            # hide service names, show icons only (all screens)
+  # icons_only: mobile          # icons-only on mobile screens only (≤840px)
   # hide_descriptions: true     # hide description text on all cards
 
   # External links shown in the sidebar (optional)

--- a/js/services.js
+++ b/js/services.js
@@ -81,7 +81,8 @@ export async function loadServices() {
 				CONFIG.refreshInterval = refresh_interval * 1000;
 			}
 
-			document.body.classList.toggle('icons-only-mode',       !!config.settings.icons_only);
+			document.body.classList.toggle('icons-only-mode',        config.settings.icons_only === true);
+			document.body.classList.toggle('icons-only-mobile-mode', config.settings.icons_only === 'mobile');
 			document.body.classList.toggle('hide-descriptions-mode', !!config.settings.hide_descriptions);
 		}
 

--- a/styles.css
+++ b/styles.css
@@ -1472,6 +1472,60 @@ body.icons-only-mode .service-status {
     margin: 0.5rem 0;
 }
 
+/* ── Mode: Icons Only on Mobile only ── */
+@media (max-width: 840px) {
+    body.icons-only-mobile-mode #services-grid:not(.view-grouped) .service-category-badge {
+        display: none;
+    }
+    body.icons-only-mobile-mode #services-grid:not(.view-grouped),
+    body.icons-only-mobile-mode .cat-section-grid {
+        grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));
+        gap: 1rem;
+    }
+    body.icons-only-mobile-mode .service-card {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        text-align: center;
+    }
+    body.icons-only-mobile-mode .card-header {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        width: 100%;
+        margin: 0;
+        gap: 0;
+    }
+    body.icons-only-mobile-mode .service-icon {
+        width: 80px;
+        height: 80px;
+        font-size: 3.5rem;
+        margin: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+    body.icons-only-mobile-mode .card-title-block {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        margin-left: 0;
+        gap: 0.5rem;
+    }
+    body.icons-only-mobile-mode .service-name {
+        display: none;
+    }
+    body.icons-only-mobile-mode .service-desc,
+    body.icons-only-mobile-mode .stats-scroll-wrapper,
+    body.icons-only-mobile-mode .service-status .status-text {
+        display: none;
+    }
+    body.icons-only-mobile-mode .service-status {
+        position: relative;
+        margin: 0.5rem 0;
+    }
+}
+
 /* Update default logo sizing */
 .service-logo-img {
     width: 70%;


### PR DESCRIPTION
## Summary
- Adds a third value for the `icons_only` setting: `"mobile"`
- When set to `mobile`, the compact icons-only grid layout is applied only on screens ≤840px (mobile), leaving the desktop layout unchanged
- `true` continues to apply icons-only on all screens as before

## Usage
```yaml
settings:
  icons_only: mobile   # icons-only on mobile only
  # icons_only: true   # icons-only on all screens (existing behaviour)
```

## Test plan
- [x] `icons_only: true` still applies icons-only on desktop and mobile
- [x] `icons_only: mobile` shows normal card layout on desktop
- [x] `icons_only: mobile` switches to compact icon grid on a mobile-width screen (≤840px)
- [x] No `icons_only` setting (or `false`) shows normal layout on all screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)